### PR TITLE
Adding Support for SwiftUI Colors

### DIFF
--- a/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
+++ b/SwiftGen.xcodeproj/xcshareddata/xcschemes/swiftgen.xcscheme
@@ -103,7 +103,7 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "--help"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--version"
@@ -179,7 +179,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "run xcassets --templateName swift5 $(PROJECT_DIR)/Tests/Fixtures/Resources/XCAssets/Food.xcassets"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "run yaml --templateName inline-swift5 $(PROJECT_DIR)/Tests/Fixtures/Resources/YAML/good/documents.yaml"

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-allValues.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -224,6 +227,11 @@ internal final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-customBundle.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -132,6 +135,11 @@ internal final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-customName.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-customName.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "XCTColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -132,6 +135,11 @@ internal final class XCTColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-forceFileNameEnum.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -132,6 +135,11 @@ internal final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-forceNamespaces.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -134,6 +137,11 @@ internal final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all-publicAccess.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -132,6 +135,11 @@ public final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  public private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/all.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/all.swift
@@ -9,6 +9,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
@@ -132,6 +135,11 @@ internal final class ColorAsset {
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name

--- a/Tests/Fixtures/Generated/XCAssets/swift5/food.swift
+++ b/Tests/Fixtures/Generated/XCAssets/swift5/food.swift
@@ -8,6 +8,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")

--- a/Tests/Fixtures/Resources/XCAssets/Food.xcassets/Contents.json
+++ b/Tests/Fixtures/Resources/XCAssets/Food.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Tests/Fixtures/Resources/XCAssets/Food.xcassets/testColor.colorset/Contents.json
+++ b/Tests/Fixtures/Resources/XCAssets/Food.xcassets/testColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "0.419",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/templates/xcassets/swift5.stencil
+++ b/templates/xcassets/swift5.stencil
@@ -20,6 +20,9 @@
 #elseif os(tvOS) || os(watchOS)
   import UIKit
 #endif
+#if canImport(SwiftUI)
+    import  SwiftUI
+#endif
 
 // Deprecated typealiases
 {% if resourceCount.color > 0 %}
@@ -181,6 +184,11 @@
     return color
   }
   #endif
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  {{accessModifier}} private(set) lazy var colorView: SwiftUI.Color = {
+    return SwiftUI.Color(name)
+  }()
 
   fileprivate init(name: String) {
     self.name = name


### PR DESCRIPTION
By simply calling `.colorView` on a color (we could also simply call `.view` or declare the color with another name (or prefixed `Color.` instead of `Asset.`?)